### PR TITLE
WIP! Do not merge! Initial move to intero

### DIFF
--- a/extensions.el
+++ b/extensions.el
@@ -28,10 +28,10 @@
   "Initialize my extension"
   (progn
     (require 'flycheck-liquid)
-    (add-hook 'haskell-mode-hook
-              '(lambda () (flycheck-select-checker 'haskell-liquid)))
-    (add-hook 'literate-haskell-mode-hook
-              '(lambda () (flycheck-select-checker 'haskell-liquid)))
+    (add-hook 'intero-mode-hook
+              '(lambda () (flycheck-select-checker 'intero-liquid)))
+    ;; (add-hook 'literate-haskell-mode-hook
+    ;;           '(lambda () (flycheck-select-checker 'haskell-liquid)))
   )
 )
 
@@ -40,7 +40,7 @@
   (progn
     (require 'flycheck-liquid)
     (require 'liquid-tip)
-    (add-hook 'haskell-mode-hook
+    (add-hook 'intero-mode-hook
                 '(lambda () (liquid-tip-mode)))
     ;; (add-hook 'haskell-mode-hook
     ;;           (lambda () (liquid-tip-init 'ascii)))

--- a/extensions/flycheck-liquid/flycheck-liquid.el
+++ b/extensions/flycheck-liquid/flycheck-liquid.el
@@ -36,12 +36,12 @@
 
 (require 'flycheck)
 
-(flycheck-define-checker haskell-liquid
+(flycheck-define-checker intero-liquid
   "A Haskell refinement type checker using liquidhaskell.
 
 See URL `https://github.com/ucsd-progsys/liquidhaskell'."
   :command
-  ("liquid" source-inplace)
+  ("stack exec liquid -- " source-inplace)
   ;; ("~/bin/Checker.hs" source-inplace)
   :error-patterns
   (
@@ -74,10 +74,10 @@ See URL `https://github.com/ucsd-progsys/liquidhaskell'."
     (-> errors
       flycheck-dedent-error-messages
       flycheck-sanitize-errors))
-  :modes (haskell-mode literate-haskell-mode)
-  :next-checkers ((warnings-only . haskell-hlint)))
+  :modes (intero-mode)
+  :next-checkers nil)
 
-(add-to-list 'flycheck-checkers 'haskell-liquid)
+(add-to-list 'flycheck-checkers 'intero-liquid)
 
 (provide 'flycheck-liquid)
 ;;; flycheck-liquid.el ends here

--- a/extensions/liquid-tip/liquid-tip.el
+++ b/extensions/liquid-tip/liquid-tip.el
@@ -39,7 +39,7 @@
 
 (defgroup liquid-tip nil
   " Liquid tip."
-  :group 'haskell
+  :group 'intero
   :prefix "liquid-tip-")
 
 (defcustom liquid-tip-style 'ascii
@@ -345,11 +345,11 @@
           (lambda () (liquid-tip-update liquid-tip-checker-name)))
 
 ;;;###autoload
-(add-hook 'haskell-mode-hook
-          '(lambda () (flycheck-select-checker 'haskell-liquid)))
-;;;###autoload
-(add-hook 'literate-haskell-mode-hook
-          '(lambda () (flycheck-select-checker 'haskell-liquid)))
+(add-hook 'intero-mode-hook
+          '(lambda () (flycheck-select-checker 'intero-liquid)))
+;;###autoload
+;; (add-hook 'literate-haskell-mode-hook
+;;           '(lambda () (flycheck-select-checker 'haskell-liquid)))
 
 ;;;###autoload
 (define-minor-mode liquid-tip-mode

--- a/packages.el
+++ b/packages.el
@@ -13,10 +13,10 @@
 (defvar liquid-types-packages
   '(
     flycheck
-    haskell-mode
+    ;; haskell-mode
     button-lock
     pos-tip
-    popup 
+    popup
     thingatpt
     ;; package liquid-typess go here
     )


### PR DESCRIPTION
So I am having a problem as you can see I moved all the hooks to intero specific hooks just trying to get a workable intero version. There is no mention of haskell mode anywhere in this fork but when I load a haskell buffer I get the following error:

``` haskell
Syntax checker in buffer Unique.hs in haskell-mode:

  intero-liquid
    - major mode: `haskell-mode' not supported
    - predicate:  nil
    - executable: Not found

Flycheck cannot use this syntax checker for this buffer.

Flycheck Mode is enabled. Use SPC u C-c ! x to enable disabled checkers.
```

Do you know whats going on?
